### PR TITLE
Simple styling + Windows (Chrome) fixes

### DIFF
--- a/soundboard.html
+++ b/soundboard.html
@@ -1,121 +1,141 @@
 <!DOCTYPE HTML>
 <html lang="en">
+
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <title>Soundboard</title>
-  <script src="./jquery-v3.4.1.min.js"></script>
-  <script type="text/javascript">
-    var sound_definitions = [
-      './effects/whoosh-crunch-1.ogg', // https://www.youtube.com/watch?v=U_Lh28jM4vc
-      './effects/red-tailed-hawk-scream.ogg', // https://www.youtube.com/watch?v=33DWqRyAAUw
-      {
-        'name': 'thunder-clap',
-        'audio': [
-          './effects/thunder-clap-1.ogg', // https://www.youtube.com/watch?v=ZHeLUVDYLIg
-          './effects/thunder-clap-2.ogg', // https://www.youtube.com/watch?v=QZpgHrKXooc
-          './effects/thunder-clap-3.ogg', // https://www.youtube.com/watch?v=QZpgHrKXooc
-          './effects/thunder-clap-4.ogg', // https://www.youtube.com/watch?v=QZpgHrKXooc
-        ],
-      },
-      './effects/flapping-wings.ogg', // https://www.youtube.com/watch?v=EDy8G89325c
-      './ambient/thunderstorm.ogg', // https://www.youtube.com/watch?v=eqabnkMmqyM
-      './music/skyrim-ost-blood-and-steel.ogg', // https://www.youtube.com/watch?v=q_AUBic3NEo
-    ];
-  </script>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Soundboard</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <style>
+        body {
+            background: url('https://i.imgur.com/XxmOifl.png') no-repeat center center fixed;
+            -webkit-background-size: cover;
+            -moz-background-size: cover;
+            background-size: cover;
+            -o-background-size: cover;
+        }
+    </style>
+    <script src="./jquery-v3.4.1.min.js"></script>
+    <script type="text/javascript">
+        var sound_definitions = [
+            './effects/whoosh-crunch-1.ogg', // https://www.youtube.com/watch?v=U_Lh28jM4vc
+            './effects/red-tailed-hawk-scream.ogg', // https://www.youtube.com/watch?v=33DWqRyAAUw
+            {
+                'name': 'thunder-clap',
+                'audio': [
+                    './effects/thunder-clap-1.ogg', // https://www.youtube.com/watch?v=ZHeLUVDYLIg
+                    './effects/thunder-clap-2.ogg', // https://www.youtube.com/watch?v=QZpgHrKXooc
+                    './effects/thunder-clap-3.ogg', // https://www.youtube.com/watch?v=QZpgHrKXooc
+                    './effects/thunder-clap-4.ogg', // https://www.youtube.com/watch?v=QZpgHrKXooc
+                ],
+            },
+            './effects/flapping-wings.ogg', // https://www.youtube.com/watch?v=EDy8G89325c
+            './ambient/thunderstorm.ogg', // https://www.youtube.com/watch?v=eqabnkMmqyM
+            './music/skyrim-ost-blood-and-steel.ogg', // https://www.youtube.com/watch?v=q_AUBic3NEo
+        ];
+    </script>
 </head>
+
 <body>
-  <div id="doc" style="display: grid; grid: auto-flow / repeat(auto-fill, 270px); grid-gap: 10px"></div>
-  <script type="text/javascript" charset="utf-8">
+    <div class="container">
+        <div id="doc" style="display: grid; grid: auto-flow / repeat(auto-fill, 300px); grid-gap: 20px; margin:20px 0px"></div>
+    </div>
+    <script type="text/javascript" charset="utf-8">
+        // Go through each sound definition and insert the HTML elements
+        // accordingly
+        for (var i = 0; i < sound_definitions.length; i += 1) {
 
-    // Go through each sound definition and insert the HTML elements
-    // accordingly
-    for (var i = 0; i < sound_definitions.length; i += 1) {
+            var sound_definition = sound_definitions[i];
+            var elem = $(
+                '<div class="audio_block bg-secondary border border-dark" style="width: 300px; margin-top:10px; padding:10px; border-radius: 20px"></div>'
+            );
 
-      var sound_definition = sound_definitions[i];
-      var elem = $(
-        '<div class="audio_block" style="width: 270px;"></div>'
-      );
-
-      var name = '';
-      if (typeof(sound_definition) == 'string') {
-        // Definitions that are just strings are assumed to be just the URL for
-        // a single audio clip.
-        var sound_url = sound_definition;
-        var sound_name = sound_url.match(/.+\/(.+)\.\w{3}/)[1];
-        elem.append($(
-          '<audio src="' + sound_url + '" controls autobuffer="true" title="' + sound_name + '" style="height: 15px;"></audio><br>'
-        ));
-        name = sound_name;
-        elem.append($('<button style="width: 100%;">' + name + '</button><br>'));
-        elem.append($('<input class="loop" type="checkbox">loop</input>'));
-      } else if (typeof(sound_definition) == 'object') {
-        // Definitions that are objects are assumed to be hash objects that
-        // have two keys: 'name' and 'audio'. The 'audio' key is expected to be
-        // an array of audio clip URLs.
-        var sound_urls = sound_definition.audio;
-        for (var j = 0; j < sound_urls.length; j += 1) {
-          var sound_url = sound_urls[j];
-          var sound_name = sound_url.match(/.+\/(.+)\.\w{3}/)[1];
-          elem.append($(
-            '<audio src="' + sound_url + '" controls autobuffer="true" title="' + sound_name + '" style="height: 15px;"></audio><br>'
-          ));
-        }
-        name = sound_definition.name;
-        elem.append($('<button style="width: 100%;">' + name + '</button><br>'));
-      }
-
-      $('#doc').append(elem);
-    }
-
-    // Do stuff after the document is done loading so that the audio clips are
-    // available for referencing
-    $(document).ready(function() {
-
-      // Go through each audio block to set up the play button handler to play
-      // some random audio in tbe audio block.
-      $('.audio_block').each(function(i, audio_block_elem) {
-        var audio_block = $(audio_block_elem);
-        var all_audio = audio_block.find('audio');
-        var audio = audio_block.find('audio')[0];
-        var audio_button = audio_block.find('button')[0];
-        $(audio_button)
-          .click(function() {
-            if (audio_block.unplayed_indices === undefined ||
-                audio_block.unplayed_indices.length == 0) {
-              audio_block.unplayed_indices = Array();
-              for (var i = 0; i < all_audio.length; i += 1) {
-                audio_block.unplayed_indices.push(i);
-              }
+            var name = '';
+            if (typeof(sound_definition) == 'string') {
+                // Definitions that are just strings are assumed to be just the URL for
+                // a single audio clip.
+                var sound_url = sound_definition;
+                var sound_name = sound_url.match(/.+\/(.+)\.\w{3}/)[1];
+                elem.append($(
+                    '<audio src="' + sound_url + '" controls autobuffer="true" title="' + sound_name + '" style="height: 25px; width: 280px"></audio><br>'
+                ));
+                name = sound_name;
+                label = 'Loop'
+                checkbox_id = 'loop' + i
+                elem.append($('<button style="width: 100%;">' + name + '</button><br>'));
+                elem.append($('<input id="' + checkbox_id + '" class="loop" type="checkbox" style="margin-right:4px">'));
+                elem.append($('<label for="' + checkbox_id + '">' + label + '</label>'));
+            } else if (typeof(sound_definition) == 'object') {
+                // Definitions that are objects are assumed to be hash objects that
+                // have two keys: 'name' and 'audio'. The 'audio' key is expected to be
+                // an array of audio clip URLs.
+                var sound_urls = sound_definition.audio;
+                for (var j = 0; j < sound_urls.length; j += 1) {
+                    var sound_url = sound_urls[j];
+                    var sound_name = sound_url.match(/.+\/(.+)\.\w{3}/)[1];
+                    elem.append($(
+                        '<audio id="audio' + i + '" src="' + sound_url + '" controls preload="metadata" autobuffer="true" title="' + sound_name + '" style="height: 25px; width: 280px"></audio><br>'
+                    ));
+                }
+                name = sound_definition.name;
+                elem.append($('<button style="width: 100%;">' + name + '</button><br>'));
             }
-            var index_into_unplayed =
-              parseInt(Math.random() * audio_block.unplayed_indices.length);
-            var index_into_audio =
-              audio_block.unplayed_indices.splice(index_into_unplayed, 1)[0];
-            var audio = all_audio[index_into_audio];
-            audio.currentTime = 0;
-            audio.play();
-          });
 
-        // If this isn't a group of audio then looping can be controlled using
-        // an input checkbox.
-        var audio_loop_checkbox = audio_block.find('.loop');
-        if (audio_loop_checkbox) {
-          audio_loop_checkbox = audio_loop_checkbox[0];
-          $(audio_loop_checkbox)
-            // If the loop checkbox is changed then we update the audio clip's
-            // looping state to match the checkbox state
-            .change(function() {
-              var checkbox = $(this);
-              $(all_audio).each(function (i, x) {
-                x.loop = checkbox.prop('checked');
-              });
-            })
-            // Automatically set audio clips that are longer than 60 seconds to
-            // loop
-            .prop('checked', (audio.loop = (audio.duration >= 60.0)));
+            $('#doc').append(elem);
         }
-      });
-    });
-  </script>
+
+        // Do stuff after the document is done loading so that the audio clips are
+        // available for referencing
+        $(document).ready(function() {
+
+            // Go through each audio block to set up the play button handler to play
+            // some random audio in the audio block.
+            $('.audio_block').each(function(i, audio_block_elem) {
+                var audio_block = $(audio_block_elem);
+                var all_audio = audio_block.find('audio');
+                var audio = audio_block.find('audio')[0];
+                var audio_button = audio_block.find('button')[0];
+
+                audio.onloadedmetadata = function() {
+                    // If this isn't a group of audio then looping can be controlled using
+                    // an input checkbox.
+                    var audio_loop_checkbox = audio_block.find('.loop');
+                    if (audio_loop_checkbox) {
+                        audio_loop_checkbox = audio_loop_checkbox[0]
+                        $(audio_loop_checkbox)
+                            // If the loop checkbox is changed then we update the audio clip's
+                            // looping state to match the checkbox state
+                            .change(function() {
+                                var checkbox = $(this);
+                                $(all_audio).each(function(i, x) {
+                                    x.loop = checkbox.prop('checked');
+                                });
+                            })
+                            // Automatically set audio clips that are longer than 60 seconds to
+                            // loop
+                            .prop('checked', (audio.loop = (audio.duration >= 60.0)));
+                    }
+                };
+
+                $(audio_button)
+                    .click(function() {
+                        if (audio_block.unplayed_indices === undefined ||
+                            audio_block.unplayed_indices.length == 0) {
+                            audio_block.unplayed_indices = Array();
+                            for (var i = 0; i < all_audio.length; i += 1) {
+                                audio_block.unplayed_indices.push(i);
+                            }
+                        }
+                        var index_into_unplayed =
+                            parseInt(Math.random() * audio_block.unplayed_indices.length);
+                        var index_into_audio =
+                            audio_block.unplayed_indices.splice(index_into_unplayed, 1)[0];
+                        var audio = all_audio[index_into_audio];
+                        audio.currentTime = 0;
+                        audio.play();
+                    });
+            });
+        });
+    </script>
 </body>
+
 </html>


### PR DESCRIPTION
Added some (simple) Bootstrap styling
Fixed some issues in Chrome (Windows):
- Loop checkboxes weren't set for audio >= 60 secs
- Element positioning was off (overlap)

P.S.: Haven't tested on any other browsers except for Chrome and only on Windows. No idea if this breaks anything on other browsers or on other OSs.